### PR TITLE
Add top-level Makefile and fix missing includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 CMakeCache.txt
 CMakeFiles
 Makefile
+!/Makefile
 cmake_install.cmake
 CTestTestfile.cmake
 compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+CMAKE ?= cmake
+BUILD_DIR ?= build
+
+.PHONY: all configure clean
+
+all: configure
+	$(CMAKE) --build $(BUILD_DIR)
+
+configure:
+	$(CMAKE) -S . -B $(BUILD_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/libsponge/util/address.cc
+++ b/libsponge/util/address.cc
@@ -3,6 +3,7 @@
 #include "util.hh"
 
 #include <arpa/inet.h>
+#include <array>
 #include <cstring>
 #include <memory>
 #include <netdb.h>

--- a/libsponge/util/buffer.cc
+++ b/libsponge/util/buffer.cc
@@ -1,5 +1,7 @@
 #include "buffer.hh"
 
+#include <stdexcept>
+
 using namespace std;
 
 void Buffer::remove_prefix(const size_t n) {


### PR DESCRIPTION
## Summary
- add a top-level Makefile that configures and builds the CMake project
- ensure the root Makefile is tracked by updating the ignore rules
- include the required standard headers in the networking utilities so they compile cleanly

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68d6660a855c8328ae187ae2801b4586